### PR TITLE
Missing SLA Config description fix

### DIFF
--- a/sla-config/object.json
+++ b/sla-config/object.json
@@ -1,6 +1,7 @@
 {
     "name": "SLA Settings",
     "image": "object.png",
+    "readme": "object.md",
     "statuses": [
         {
             "id": "s-a-disabled",


### PR DESCRIPTION
SLA Config object misses description on the CloudBlue Connect Community website